### PR TITLE
specify that masterData is in the form of json

### DIFF
--- a/lib/countrysynonyms.js
+++ b/lib/countrysynonyms.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const data = require('./data/masterData');
+const data = require('./data/masterData.json');
 
 function iso3(code, language = 'en') {
 	return country(code, language).ISO3;


### PR DESCRIPTION
For other setups, the module cannot be resolved unless the file type is specified, e.g. `.ts` or `.json`.